### PR TITLE
Malformed auth header

### DIFF
--- a/dropler/plugin.js
+++ b/dropler/plugin.js
@@ -107,7 +107,7 @@ CKEDITOR.plugins.add( 'dropler', {
 
         function uploadImgur(file) {
             var settings = editor.config.droplerConfig.settings;
-            return post('https://api.imgur.com/3/image', file, {'Authorization': settings.clientId});
+            return post('https://api.imgur.com/3/image', file, {'Authorization': 'Client-ID ' + settings.clientId});
         }
 
         function uploadS3(file) {


### PR DESCRIPTION
I was receiving a "malformed auth header" error message when uploading to Imgur. I checked the Imgur docs and it said the authorization header should be 'Authorization': 'Client-ID ' + settings.clientId. The current build of Droppler was not using "Client-ID"

https://api.imgur.com/#authentication
