### PR TITLE
Connect plugin to active ckeditor instance - Closes #6

### DIFF
--- a/dropler/plugin.js
+++ b/dropler/plugin.js
@@ -126,7 +126,9 @@ CKEDITOR.plugins.add( 'dropler', {
         };
 
         CKEDITOR.on('instanceReady', function() {
-            var iframeBase = document.querySelector('iframe').contentDocument.querySelector('html');
+            var container = editor.container;
+            var iframe = jQuery(container.$).find('iframe')[0];
+            var iframeBase = iframe.contentDocument.querySelector('html');
             var iframeBody = iframeBase.querySelector('body');
 
             iframeBody.ondragover = doNothing;


### PR DESCRIPTION
This fixes a problem I was seeing when using this plugin on a page
that has more than one iframe. It would be great to not rely on jQuery
here - I just don't know off the top of my head how to query dom
children with plain javascript.